### PR TITLE
UX fix for signal props editor

### DIFF
--- a/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/action/EditSignalElementPropertiesAction.java
+++ b/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/action/EditSignalElementPropertiesAction.java
@@ -347,6 +347,8 @@ public class EditSignalElementPropertiesAction extends AbstractAction
 
       setContentPane( contentPane );
 
+      getRootPane().setDefaultButton( okButton );
+
       pack();
     }
   }


### PR DESCRIPTION
This patch sets the default button of the signal properties editor to the Ok button, making the dialog a bit more keyboard-friendly.
