### PR TITLE
Issue #167: Really make sure the last value is always present

### DIFF
--- a/api/src/main/java/nl/lxtreme/ols/api/data/CapturedData.java
+++ b/api/src/main/java/nl/lxtreme/ols/api/data/CapturedData.java
@@ -177,9 +177,9 @@ public class CapturedData implements AcquisitionResult
         if ( aValues[i] != oldValue )
         {
           count++;
+          lastTimestamp = aTimestamps[i];
         }
         oldValue = aValues[i];
-        lastTimestamp = aTimestamps[i];
       }
 
       // Issue #167: make sure the absolute length is *always* present...
@@ -280,9 +280,9 @@ public class CapturedData implements AcquisitionResult
         if ( value.compareTo( oldValue ) != 0 )
         {
           count++;
+          lastTimestamp = aTimestamps.get( i );
         }
         oldValue = value;
-        lastTimestamp = aTimestamps.get( i );
       }
 
       // Issue #167: make sure the absolute length is *always* present...


### PR DESCRIPTION
Even with previous attempts to fix this issue, it still persisted for me
(though I didn't notice it on all captures, but it could be that I
didn't notice this if there was a captured value near the end). I
suspect that perhaps the RLE decoder is unaffected or something, my Bus
Pirate uses unencoded output.

What happened was that the duplicate sample removal in CapturedData
would kill the last sample, because it is (by the way EqualityFilter
works) always identical to the next to last sample. However, it would
still record its timestamp for the purposes of the "do we need to add a
final sample" check, so no final sample would be added. This would break
the signal display, truncating it at the last change in a signal.
