### PR TITLE
Let run.sh forward options to java

### DIFF
--- a/ols.distribution/src/main/resources/run.sh
+++ b/ols.distribution/src/main/resources/run.sh
@@ -33,4 +33,4 @@ classpath="$basedir/bin/*"
 
 # give the client roughly 1gigabyte of memory 
 MEMSETTINGS=-Xmx1024m
-java "$MEMSETTINGS" -Djna.nosys=true -Dnl.lxtreme.ols.bundle.dir="$plugindir" -DPlastic.defaultTheme=SkyBluer -cp "$classpath" nl.lxtreme.ols.runner.Runner
+java "$@" "$MEMSETTINGS" -Djna.nosys=true -Dnl.lxtreme.ols.bundle.dir="$plugindir" -DPlastic.defaultTheme=SkyBluer -cp "$classpath" nl.lxtreme.ols.runner.Runner


### PR DESCRIPTION
This allows for example to enable log output by running
"run.sh -Dnl.lxtreme.ols.logToConsole=true" without having to modify the
run.sh script.
