### PR TITLE
Add devices profiles for the Arduino Generic Logic Analyzer sketch.

### DIFF
--- a/ols.distribution/src/main/config/ols.profile-agla.cfg
+++ b/ols.distribution/src/main/config/ols.profile-agla.cfg
@@ -1,0 +1,55 @@
+# Configuration for Arduino Generic Logic Analyzer profile
+
+# The short (single word) type of the device described in this profile
+device.type = AGLA
+# A longer description of the device
+device.description = Arduino Generic Logic Analyzer
+# The device interface, SERIAL only
+device.interface = SERIAL
+# The device's native clockspeed, in Hertz.
+device.clockspeed = 16000000
+# The clockspeed used in the divider calculation, in Hertz. Defaults to 100MHz as most devices appear to use this.
+device.dividerClockspeed = 100000000
+# Whether or not double-data-rate is supported by the device (also known as the "demux"-mode).
+device.supports_ddr = false
+# Supported sample rates in Hertz, separated by comma's
+device.samplerates = 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000
+# What capture clocks are supported
+device.captureclock = INTERNAL
+# The supported capture sizes, in bytes
+device.capturesizes = 64, 128, 256, 512, 1024
+# Whether or not the noise filter is supported
+device.feature.noisefilter = false
+# Whether or not Run-Length encoding is supported
+device.feature.rle = true
+# Whether or not a testing mode is supported
+device.feature.testmode = false
+# Whether or not triggers are supported
+device.feature.triggers = true
+# The number of trigger stages
+device.trigger.stages = 1
+# Whether or not "complex" triggers are supported
+device.trigger.complex = false
+
+# The total number of channels usable for capturing
+device.channel.count = 6
+# The number of channels groups, together with the channel count determines the channels per group
+device.channel.groups = 1
+# Whether the capture size is limited by the enabled channel groups
+device.capturesize.bound = false
+# Which numbering does the device support
+device.channel.numberingschemes = DEFAULT
+
+# Is a delay after opening the port and device detection needed? (0 = no delay, >0 = delay in milliseconds)
+device.open.portdelay = 1500
+# The receive timeout for the device (in milliseconds, 100 = default, <=0 = no timeout)
+device.receive.timeout = 100
+# Does the device need a high or low DTR-line to operate correctly? (high = true, low = false)
+device.open.portdtr = true
+# Which metadata keys correspond to this device profile? Value is a comma-separated list of (double quoted) names...
+device.metadata.keys = "AGLAv0"
+
+# In which order are samples sent back from the device? false = last sample first, true = first sample first
+device.samples.reverseOrder = true
+
+###EOF###

--- a/ols.distribution/src/main/config/ols.profile-aglam.cfg
+++ b/ols.distribution/src/main/config/ols.profile-aglam.cfg
@@ -1,0 +1,55 @@
+# Configuration for Arduino Mega Logic Analyzer profile
+
+# The short (single word) type of the device described in this profile
+device.type = AGLAM
+# A longer description of the device
+device.description = Arduino Mega Logic Analyzer
+# The device interface, SERIAL only
+device.interface = SERIAL
+# The device's native clockspeed, in Hertz.
+device.clockspeed = 16000000
+# The clockspeed used in the divider calculation, in Hertz. Defaults to 100MHz as most devices appear to use this.
+device.dividerClockspeed = 100000000
+# Whether or not double-data-rate is supported by the device (also known as the "demux"-mode).
+device.supports_ddr = false
+# Supported sample rates in Hertz, separated by comma's
+device.samplerates = 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000
+# What capture clocks are supported
+device.captureclock = INTERNAL
+# The supported capture sizes, in bytes
+device.capturesizes = 64, 128, 256, 512, 1024, 2048, 4096, 7168
+# Whether or not the noise filter is supported
+device.feature.noisefilter = false
+# Whether or not Run-Length encoding is supported
+device.feature.rle = false
+# Whether or not a testing mode is supported
+device.feature.testmode = false
+# Whether or not triggers are supported
+device.feature.triggers = true
+# The number of trigger stages
+device.trigger.stages = 1
+# Whether or not "complex" triggers are supported
+device.trigger.complex = false
+
+# The total number of channels usable for capturing
+device.channel.count = 8
+# The number of channels groups, together with the channel count determines the channels per group
+device.channel.groups = 1
+# Whether the capture size is limited by the enabled channel groups
+device.capturesize.bound = false
+# Which numbering does the device support
+device.channel.numberingschemes = DEFAULT
+
+# Is a delay after opening the port and device detection needed? (0 = no delay, >0 = delay in milliseconds)
+device.open.portdelay = 2000
+# The receive timeout for the device (in milliseconds, 100 = default, <=0 = no timeout)
+device.receive.timeout = 100
+# Does the device need a high or low DTR-line to operate correctly? (high = true, low = false)
+device.open.portdtr = true
+# Which metadata keys correspond to this device profile? Value is a comma-separated list of (double quoted) names...
+device.metadata.keys = "AGLAMv0"
+
+# In which order are samples sent back from the device? false = last sample first, true = first sample first
+device.samples.reverseOrder = true
+
+###EOF###


### PR DESCRIPTION
Add profiles for the ATmega328 and ATmega2560 based Arduinos using the
logic analyzer sketch from here:
https://github.com/gillham/logic_analyzer
