### PR TITLE
Increase portdelay so the Arduino Uno R3 works.

### DIFF
--- a/ols.distribution/src/main/config/ols.profile-agla.cfg
+++ b/ols.distribution/src/main/config/ols.profile-agla.cfg
@@ -41,7 +41,7 @@ device.capturesize.bound = false
 device.channel.numberingschemes = DEFAULT
 
 # Is a delay after opening the port and device detection needed? (0 = no delay, >0 = delay in milliseconds)
-device.open.portdelay = 1500
+device.open.portdelay = 2000
 # The receive timeout for the device (in milliseconds, 100 = default, <=0 = no timeout)
 device.receive.timeout = 100
 # Does the device need a high or low DTR-line to operate correctly? (high = true, low = false)


### PR DESCRIPTION
The Arduino Uno R3 requires a longer device.open.portdelay compared to
older Arduino boards.
This fixes the reported issue of device timeouts.  Tested on Mac OSX
and Windows and the R3 works fine with this delay.  Also tested against
original Uno, Duemilenove, Seeeduino and they still work.
