### PR TITLE
Add buttons for easy manipulation of basic triggers from the main display

### DIFF
--- a/client/src/main/java/nl/lxtreme/ols/client/ClientController.java
+++ b/client/src/main/java/nl/lxtreme/ols/client/ClientController.java
@@ -314,7 +314,7 @@ public final class ClientController implements ActionProvider, AcquisitionProgre
 
     this.actionManager = new ActionManager();
 
-    this.signalDiagramController = new SignalDiagramController( this.actionManager );
+    this.signalDiagramController = new SignalDiagramController( this.actionManager, this );
 
     Runnable runner = new Runnable()
     {

--- a/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/SignalDiagramController.java
+++ b/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/SignalDiagramController.java
@@ -31,7 +31,9 @@ import nl.lxtreme.ols.api.acquisition.AcquisitionResult;
 import nl.lxtreme.ols.api.data.*;
 import nl.lxtreme.ols.api.data.Cursor;
 import nl.lxtreme.ols.api.data.project.*;
+import nl.lxtreme.ols.api.devices.Device;
 import nl.lxtreme.ols.client.Activator;
+import nl.lxtreme.ols.client.ClientController;
 import nl.lxtreme.ols.client.action.*;
 import nl.lxtreme.ols.client.actionmanager.*;
 import nl.lxtreme.ols.client.signaldisplay.ZoomController.ZoomEvent;
@@ -58,6 +60,7 @@ public final class SignalDiagramController implements ZoomListener, PropertyChan
 
   private SignalDiagramModel signalDiagramModel;
   private SignalDiagramComponent signalDiagram;
+  private final ClientController clientController;
 
   // CONSTRUCTORS
 
@@ -67,10 +70,10 @@ public final class SignalDiagramController implements ZoomListener, PropertyChan
    * @param aActionManager
    *          the action manager to use, cannot be <code>null</code>.
    */
-  public SignalDiagramController( final IActionManager aActionManager )
+  public SignalDiagramController( final IActionManager aActionManager, final ClientController clientController )
   {
     this.actionManager = aActionManager;
-
+    this.clientController = clientController;
     this.dndTargetController = new DragAndDropTargetController( this );
   }
 
@@ -641,7 +644,7 @@ public final class SignalDiagramController implements ZoomListener, PropertyChan
   /**
    * @return
    */
-  private ChannelLabelsView getChannelLabelsView()
+  public ChannelLabelsView getChannelLabelsView()
   {
     JScrollPane scrollPane = getAncestorOfClass( JScrollPane.class, getSignalDiagram() );
     if ( scrollPane != null )
@@ -658,5 +661,10 @@ public final class SignalDiagramController implements ZoomListener, PropertyChan
   private long locationToTimestamp( final Point aPoint )
   {
     return this.signalDiagram.getModel().locationToTimestamp( aPoint );
+  }
+  
+  public Device getDevice()
+  {
+	return this.clientController.getDevice();  
   }
 }

--- a/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/laf/ChannelLabelsUI.java
+++ b/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/laf/ChannelLabelsUI.java
@@ -83,7 +83,7 @@ public class ChannelLabelsUI extends ComponentUI
       // Nothing to do!
       return;
     }
-
+    
     Graphics2D canvas = ( Graphics2D )aGraphics.create();
 
     try
@@ -279,6 +279,23 @@ public class ChannelLabelsUI extends ComponentUI
 
       aCanvas.setFont( labelFont );
       drawLabel( aCanvas, aModel, label, labelColor, labelXpos, labelYpos );
+
+      
+      ChannelLabelsViewModel.TriggerStatus status = aModel.getTriggerStatus(aElement.getChannel().getIndex());      
+      if (status != ChannelLabelsViewModel.TriggerStatus.UNDEFINED)
+      {
+    	  aCanvas.setColor( aElement.getColor() );
+    	  aCanvas.drawRoundRect(0, 10, 16, 16, 2, 2);
+
+    	  if (status != ChannelLabelsViewModel.TriggerStatus.DISABLED)
+    	  {
+    		  int offset = status == ChannelLabelsViewModel.TriggerStatus.LEVEL_LOW ? 9 : 0;
+    		  aCanvas.setColor(aModel.getTextShadowColor());      
+    		  aCanvas.fillRect(4, 14 + offset, 11, 2);
+    		  aCanvas.setColor(labelColor);      
+    		  aCanvas.fillRect(2, 12 + offset, 11, 2);
+    	  }
+      }
     }
 
     if ( indexDefined )

--- a/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/view/ChannelLabelsView.java
+++ b/client/src/main/java/nl/lxtreme/ols/client/signaldisplay/view/ChannelLabelsView.java
@@ -35,6 +35,7 @@ import nl.lxtreme.ols.client.signaldisplay.dnd.*;
 import nl.lxtreme.ols.client.signaldisplay.dnd.DragAndDropTargetController.DragAndDropHandler;
 import nl.lxtreme.ols.client.signaldisplay.laf.*;
 import nl.lxtreme.ols.client.signaldisplay.model.*;
+import nl.lxtreme.ols.client.signaldisplay.model.ChannelLabelsViewModel.TriggerStatus;
 import nl.lxtreme.ols.client.signaldisplay.signalelement.*;
 import nl.lxtreme.ols.client.signaldisplay.util.*;
 import nl.lxtreme.ols.client.signaldisplay.view.renderer.*;
@@ -73,7 +74,7 @@ public class ChannelLabelsView extends AbstractViewLayer
     {
       // Ensure the focus is moved to the main signal diagram component...
       getSignalDiagram().requestFocusInWindow();
-
+     
       if ( !aEvent.isConsumed() && ( aEvent.getClickCount() == 2 ) )
       {
         final IUIElement element = findSignalElement( aEvent.getPoint() );
@@ -87,6 +88,33 @@ public class ChannelLabelsView extends AbstractViewLayer
           aEvent.consume();
         }
       }
+      
+      if ( !aEvent.isConsumed() && ( aEvent.getButton() == 1 ) )
+      {
+        final IUIElement element = findSignalElement( aEvent.getPoint() );
+        if ( element != null && aEvent.getX() < this.getSignalDiagram().getX() + 16 )
+        {
+            SignalElement signalElement = ( SignalElement )element;
+            ChannelLabelsView view = controller.getChannelLabelsView();
+            
+            int channel = signalElement.getChannel().getIndex();
+            TriggerStatus status = view.getModel().getTriggerStatus(channel);            
+            switch(status)
+            {
+            case DISABLED: status = TriggerStatus.LEVEL_LOW; break;
+            case LEVEL_LOW: status = TriggerStatus.LEVEL_HIGH; break;
+            case LEVEL_HIGH: status = TriggerStatus.DISABLED; break;
+            }
+            view.getModel().setTriggerStatus(channel, status);
+
+            Rectangle rect = new Rectangle( 0, element.getYposition(), view.getWidth(), element.getHeight() );
+            view.repaint(rect);
+            
+          // Do not process this event any further...
+          aEvent.consume();
+        }
+      }
+
     }
 
     /**
@@ -516,7 +544,7 @@ public class ChannelLabelsView extends AbstractViewLayer
   @Override
   public final void updateUI()
   {
-    setUI( new ChannelLabelsUI() );
+    setUI( new ChannelLabelsUI());
   }
 
   /**

--- a/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferConfig.java
+++ b/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferConfig.java
@@ -730,6 +730,22 @@ public final class LogicSnifferConfig
     }
   }
 
+  public void setBasicTrigger(final int aMask, final int aValue)
+  {
+	int aStage = 0;
+    if ( isDoubleDataRateEnabled() )
+    {
+    	this.triggerMask[aStage] = ( aMask & 0xFFFF ) | ( ( aMask & 0xFFFF ) << 16 );
+    	this.triggerValue[aStage] = ( aValue & 0xFFFF ) | ( ( aValue & 0xFFFF ) << 16 );
+	}
+    else
+    {
+    	this.triggerMask[aStage] = aMask;
+    	this.triggerValue[aStage] = aValue;
+	}
+    this.triggerConfig[aStage] |= TRIGGER_CAPTURE;	  
+  }
+  
   /**
    * Sets the ratio for samples to read before and after started.
    * 

--- a/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferDevice.java
+++ b/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferDevice.java
@@ -64,6 +64,11 @@ public class LogicSnifferDevice implements Device
 
   // METHODS
 
+  public LogicSnifferConfig getConfig()
+  {
+	  return config;
+  }
+  
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
A bit of a hack, you can still see some magic numbers sprinkled, but from my last pull request I know you like to rewrite these things anyway :)

So the idea is that when debugging some hw you want to easily adjust triggers and recapture with as few clicks as possible. Of course the trade off is with screen space. You could potentially have off,high,low trigger buttons for each channel.

With this implementation there is a small display on each channel label that cycles as you click.

We may also want to consider adding transition triggers using more than just the first trigger stage.
