### PR TITLE
Sump device capture init failure (blocking read & retry limit)

### DIFF
--- a/ols.device/src/nl/lxtreme/ols/device/sump/SumpAcquisitionTask.java
+++ b/ols.device/src/nl/lxtreme/ols/device/sump/SumpAcquisitionTask.java
@@ -436,11 +436,6 @@ public class SumpAcquisitionTask implements SumpProtocolConstants, Task<Acquisit
           {
             LOG.log( Level.INFO, "Read zero bytes?! Stats = [{0}/{1}/{2}].", new Object[] { offset, count, zerosRead } );
           }
-
-          if ( ++zerosRead == 10000 )
-          {
-            throw new IOException( "Device did not respond with any data within valid time bound!" );
-          }
         }
         else
         {

--- a/ols.device/src/nl/lxtreme/ols/device/sump/protocol/SumpResultReader.java
+++ b/ols.device/src/nl/lxtreme/ols/device/sump/protocol/SumpResultReader.java
@@ -164,7 +164,7 @@ public class SumpResultReader implements Closeable, SumpProtocolConstants
   }
 
   /**
-   * Reads raw data from the contained input stream.
+   * Reads raw data from the contained input stream, non blocking
    * 
    * @return the integer sample value containing up to four read bytes, not
    *         aligned.
@@ -173,7 +173,14 @@ public class SumpResultReader implements Closeable, SumpProtocolConstants
    */
   public int readRawData( byte[] aBuffer, int aOffset, int aCount ) throws IOException
   {
-    return this.inputStream.read( aBuffer, aOffset, aCount );
+    int availableCount = this.inputStream.available();
+    if(availableCount<=0) {
+      return availableCount;
+    }
+    if(availableCount>aCount) {
+      availableCount = aCount;
+    }
+    return this.inputStream.read( aBuffer, aOffset, availableCount);
   }
 
   /**

--- a/ols.device/src/nl/lxtreme/ols/device/sump/protocol/SumpResultReader.java
+++ b/ols.device/src/nl/lxtreme/ols/device/sump/protocol/SumpResultReader.java
@@ -174,13 +174,15 @@ public class SumpResultReader implements Closeable, SumpProtocolConstants
   public int readRawData( byte[] aBuffer, int aOffset, int aCount ) throws IOException
   {
     int availableCount = this.inputStream.available();
-    if(availableCount<=0) {
+    if ( availableCount <= 0 )
+    {
       return availableCount;
     }
-    if(availableCount>aCount) {
+    if ( availableCount > aCount )
+    {
       availableCount = aCount;
     }
-    return this.inputStream.read( aBuffer, aOffset, availableCount);
+    return this.inputStream.read( aBuffer, aOffset, availableCount );
   }
 
   /**


### PR DESCRIPTION
While testing the latest code snapshot with a Sump device, I discovered that the capture was failing.

At first due to a blocking read operation that was used to flush data during initialization.

Secondly the capture was initializing, but failing with a timeout before managing to trigger the hardware Sump device. To avoid this the retry limit was removed (since Stop button is expected to stop or cancel an acquisition attempt).

PS: A second commit was made to fix a small code formatting nonconformity that I introduced while implementing the above mentioned changes.