### PR TITLE
issue #236 - removed SUMP 512kB sample upper limit

### DIFF
--- a/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferAcquisitionTask.java
+++ b/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferAcquisitionTask.java
@@ -108,6 +108,7 @@ public class LogicSnifferAcquisitionTask implements SumpProtocolConstants, Acqui
     final int sampleCount = this.config.getSampleCount();
     if ( sampleCount <= 0 )
     {
+      LOG.log( Level.WARNING, "Internal error: did not obtain correct number of samples (" + sampleCount + ")?!" );
       throw new InternalError( "Internal error: did not obtain correct number of samples (" + sampleCount + ")?!" );
     }
 

--- a/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferConfig.java
+++ b/device.logicsniffer/src/main/java/org/sump/device/logicsniffer/LogicSnifferConfig.java
@@ -334,19 +334,7 @@ public final class LogicSnifferConfig
    */
   public int getSampleCount()
   {
-    int samples;
-    if ( isDoubleDataRateEnabled() )
-    {
-      // When the multiplexer is turned on, the upper two channel blocks are
-      // disabled, leaving only 16 channels for capturing...
-      samples = getReadCounter() & 0xffff8;
-    }
-    else
-    {
-      samples = getReadCounter() & 0xffffc;
-    }
-
-    return samples;
+    return getReadCounter();
   }
 
   /**
@@ -777,7 +765,7 @@ public final class LogicSnifferConfig
     {
       throw new IllegalArgumentException( "Sample count cannot be zero!" );
     }
-    this.size = aCount & 0xFFFFF;
+    this.size = aCount;// & 0xFFFFF;
   }
 
   /**


### PR DESCRIPTION
I do not yet understand why the sample count limit of a specific device is enforced in software when it is possible to have devices that can perform better without (apparently) breaking backward compatibility. This is interesting especially since the limitation is enforced completely transparent to the user without giving any clear error or warning about the sample trimming. Further more, in cases where the expected sample count is a power of two greater than the imposed limit, the result will automatically be trimmed to zero which practically stops the capture process. Yet another observation regarding the InternalError object: it seems to me it does not produce any log entry even when the finest level is selected.