### PR TITLE
fixed 1wire test according to maxim integrated AN126

### DIFF
--- a/tool.1wire/src/main/java/nl/lxtreme/ols/tool/onewire/OneWireTiming.java
+++ b/tool.1wire/src/main/java/nl/lxtreme/ols/tool/onewire/OneWireTiming.java
@@ -68,7 +68,7 @@ final class OneWireTiming
       this.hMin = 480;
       this.hMax = 640;
       this.iMin = 15;
-      this.iMax = 60;
+      this.iMax = 70;
       this.jMin = 410;
     }
     else if ( OneWireBusMode.OVERDRIVE == aMode )


### PR DESCRIPTION
The timing adjustments I previously proposed were based on the specs from http://pdfserv.maximintegrated.com/en/an/AN937.pdf, but in the tests one of the sample files was exceeding those specifications.

Since this was discovered I researched further and found at https://www.maximintegrated.com/en/app-notes/index.mvp/id/126 that the master samples for the presence pulse slightly later, at 70us after releasing the line. Although 70us is still smaller than 75.3 (as it was before my adjustments) the test is now passing, as all the other tests pass also.