### PR TITLE
A fix for Issue 250: https://github.com/jawi/ols/issues/250

### DIFF
--- a/ols.distribution/src/main/resources/run.bat
+++ b/ols.distribution/src/main/resources/run.bat
@@ -31,6 +31,7 @@ rem give the client roughly 1gigabyte of memory
 set MEMSETTINGS=-Xmx1024m
 rem <https://github.com/jawi/ols/issues/125>
 set SYSPROPS=-Djna.nosys=true
+set JDK_JAVA_OPTIONS=--add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED
 
 rem For now, use the "console enabled" java for Windows...
 java %PLATFORMOPTS% %MEMSETTINGS% %SYSPROPS% -cp "%CLASSPATH%" nl.lxtreme.ols.runner.Runner -pluginDir="%PLUGINDIR%" %*

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,11 @@
 				<version>2.21.0</version>
 				<inherited>true</inherited>
 				<configuration>
-					<forkMode>once</forkMode>
+					<forkMode>once</forkMode>					
+					<argLine>
+						--add-opens java.base/java.lang=ALL-UNNAMED
+						--add-opens java.desktop/java.awt=ALL-UNNAMED
+					</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This fix allows the program to run on later versions of Java where the module loader is more restrictive. 
See https://stackoverflow.com/questions/74006627/module-java-base-does-not-opens-java-lang-java-17-0-4-1 for the rationale.